### PR TITLE
Generally just style fixes and little improvements.

### DIFF
--- a/lib/concierge/controller.ex
+++ b/lib/concierge/controller.ex
@@ -4,8 +4,8 @@ defmodule Concierge.Controller do
 
     def unauthenticated(conn, _params) do
       conn 
-        |> put_flash(:error, "Unauthenticated")
-        |> redirect(to: "/")
+      |> put_flash(:error, "Unauthenticated")
+      |> redirect(to: "/")
     end  
   end
 
@@ -29,11 +29,13 @@ defmodule Concierge.Controller do
     cond do
       Enum.any?(only) ->
         quote do
-          plug Guardian.Plug.EnsureAuthenticated, [handler: unquote(handler)] when var!(action) in unquote(only) 
+          plug Guardian.Plug.EnsureAuthenticated, [
+            handler: unquote(handler)] when var!(action) in unquote(only) 
         end
       Enum.any?(except) ->
         quote do
-          plug Guardian.Plug.EnsureAuthenticated, [handler: unquote(handler)] when not var!(action) in unquote(except) 
+          plug Guardian.Plug.EnsureAuthenticated, [
+            handler: unquote(handler)] when not var!(action) in unquote(except) 
         end
       true ->  
         quote do

--- a/lib/concierge/plug/authentication.ex
+++ b/lib/concierge/plug/authentication.ex
@@ -8,7 +8,7 @@ defmodule Concierge.Plug.Authentication do
   @doc false
   def call(conn, opts) do
     conn 
-      |> Guardian.Plug.VerifySession.call(opts)
-      |> Guardian.Plug.LoadResource.call(opts)
+    |> Guardian.Plug.VerifySession.call(opts)
+    |> Guardian.Plug.LoadResource.call(opts)
   end
 end

--- a/lib/concierge/resource.ex
+++ b/lib/concierge/resource.ex
@@ -39,8 +39,8 @@ defmodule Concierge.Resource do
 
         res = 
           changeset 
-            |> with_encrypted_password
-            |> Concierge.repo.insert
+          |> with_encrypted_password
+          |> Concierge.repo.insert
 
         case res do
           {:ok, resource} -> Enum.map(Concierge.extensions, fn(ex) -> ex.after_create(resource) end)
@@ -91,8 +91,8 @@ defmodule Concierge.Resource do
   defp with_encrypted_password(changeset) do
     encrypted_password = Comeonin.Bcrypt.hashpwsalt(changeset.params["password"])
 
-    changeset |>
-      Ecto.Changeset.put_change(:encrypted_password, encrypted_password)
+    changeset 
+    |> Ecto.Changeset.put_change(:encrypted_password, encrypted_password)
   end
 
   @doc """

--- a/lib/mix/tasks/concierge.install.ex
+++ b/lib/mix/tasks/concierge.install.ex
@@ -1,45 +1,47 @@
 defmodule Mix.Tasks.Concierge.Install do
-	use Mix.Task
+  use Mix.Task
 
-	@shortdoc "Generates basic scaffold for Concierge"
+  @shortdoc "Generates basic scaffold for Concierge"
 
-	@moduledoc """
-	Generates scaffold for Concierge
+  @moduledoc """
+  Generates scaffold for Concierge
 
-		mix concierge.install User users
-	"""
+    mix concierge.install User users
+  """
 
-	def run(args) do
-		{opts, parsed, _}	= OptionParser.parse(args)
-		[singular, plural | attrs] = validate_args!(parsed)
+  def run(args) do
+    {_opts, parsed, _} = OptionParser.parse(args)
+    [singular, plural | _attrs] = validate_args!(parsed)
 
-		binding = Mix.Phoenix.inflect(singular)
-		binding = binding ++ [plural: plural]
-		path = binding[:path]
+    binding = Mix.Phoenix.inflect(singular)
+    binding = binding ++ [plural: plural]
+    path = binding[:path]
 
-		Mix.Phoenix.check_module_name_availability!(binding[:module])
+    Mix.Phoenix.check_module_name_availability!(binding[:module])
 
-		Mix.Phoenix.copy_from paths, "priv/templates/concierge.install", "", binding, [
-			{:eex, "model.ex", "web/models/#{path}.ex"},
-			{:eex, "migration.exs", "priv/repo/migrations/#{timestamp()}_create_concierge_#{String.replace(path, "/", "_")}.exs"},
+    Mix.Phoenix.copy_from paths, "priv/templates/concierge.install", "", binding, [
+      {:eex, "model.ex", "web/models/#{path}.ex"},
+      {:eex, "migration.exs", 
+        "priv/repo/migrations/#{timestamp()}_create_concierge_#{String.replace(path, "/", "_")}.exs"},
       {:eex, "guardian_serializer.ex", "lib/concierge/guardian_serializer.ex"},
       {:eex, "config.exs", "config/concierge.exs"}
-		]
+    ]
     # TODO add instructions
-	end
+  end
 
-	defp validate_args!([_, plural] = args) do
-		cond do
+  defp validate_args!([_, plural] = args) do
+    cond do
       plural != Phoenix.Naming.underscore(plural) ->
-        Mix.raise "Expected the second argument, #{inspect plural}, to be all lowercase using snake_case convention"
+        Mix.raise "Expected the second argument, #{inspect plural}, 
+          to be all lowercase using snake_case convention"
       true ->
         args
     end
-	end
+  end
 
-	defp validate_args!(_) do
-		raise_with_help
-	end
+  defp validate_args!(_) do
+    raise_with_help
+  end
 
   defp raise_with_help do
     Mix.raise """

--- a/test/controllers/sessions_controller_test.exs
+++ b/test/controllers/sessions_controller_test.exs
@@ -17,9 +17,18 @@ defmodule Concierge.SessionsControllerTest do
   end
 
   test "sign in", %{conn: conn} do
-    {:ok, user = %Concierge.TestUser{}} = Concierge.Resource.create(%{"email" => "concierge@test.com", "password" => "123456789", "password_confirmation" => "123456789"})
+    {:ok, _user = %Concierge.TestUser{}} = Concierge.Resource.create(%{
+      "email" => "concierge@test.com", 
+      "password" => "123456789", 
+      "password_confirmation" => "123456789",
+    })
 
-    conn = post(conn, Concierge.route_helpers.sessions_path(conn, :new, %{ "user" => %{ "email" => "concierge@test.com", "password" => "123456789"} }))
+    conn = post(conn, Concierge.route_helpers.sessions_path(conn, :new, %{
+      "user" => %{ 
+        "email" => "concierge@test.com", 
+        "password" => "123456789",
+      }
+    }))
 
     assert conn.status == 302
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
+Mix.Task.run "ecto.drop", ["quiet", "-r", "Concierge.TestRepo"] # guaraties new clean db.
 Mix.Task.run "ecto.create", ["quiet", "-r", "Concierge.TestRepo"]
 Mix.Task.run "ecto.migrate", ["-r", "Concierge.TestRepo"]
 

--- a/web/controllers/concierge/registrations_controller.ex
+++ b/web/controllers/concierge/registrations_controller.ex
@@ -12,7 +12,7 @@ defmodule Concierge.RegistrationsController do
       {:ok, user} -> sign_in_and_redirect(conn, user)        
       {:error, changeset} ->
         conn           
-          |> render("new.html", changeset: changeset)    
+        |> render("new.html", changeset: changeset)    
     end
   end
 end

--- a/web/controllers/concierge/sessions_controller.ex
+++ b/web/controllers/concierge/sessions_controller.ex
@@ -12,15 +12,15 @@ defmodule Concierge.SessionsController do
       {:ok, user} -> sign_in_and_redirect(conn, user)       
       {:error, changeset} -> 
         conn           
-          |> put_flash(:error, "Invalid credentials")
-          |> put_status(422)
-          |> render("new.html", changeset: changeset)
+        |> put_flash(:error, "Invalid credentials")
+        |> put_status(:unprocessable_entity)
+        |> render("new.html", changeset: changeset)
     end      
   end
 
   def destroy(conn, _params) do
     Concierge.Session.sign_out(conn)
-      |> put_flash(:info, "Logged out successfully.")
-      |> redirect(to: "/")
+    |> put_flash(:info, "Logged out successfully.")
+    |> redirect(to: "/")
   end
 end

--- a/web/views/error_view.ex
+++ b/web/views/error_view.ex
@@ -1,0 +1,3 @@
+defmodule Concierge.ErrorView do
+  use Concierge.Web, :view
+end


### PR DESCRIPTION
Such as:
1. More consistent `|>` operator usage
2. Droping database on tests start
3. Splited long lines to fit the screen
4. Using http-status names, not codes
5. Underscoring unused variables to remove warnings

As you don't (yet) have CI, my tests pass like this:

> [12:19:42] sobolev :: MacBook-Pro-Nikita  ➜  Documents/github/concierge.ex ‹master› » mix test
> The database for Concierge.TestRepo has been dropped.
> The database for Concierge.TestRepo has been created.
> ..........
> 
> Finished in 4.2 seconds (0.1s on load, 4.1s on tests)
> 10 tests, 0 failures
> 
> Randomized with seed 43246
